### PR TITLE
feat: add Dockerfile and docker publish action

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,48 @@
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches: ['main']
+    tags: [ 'v*.*.*' ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM rust:latest
+
+WORKDIR /build
+COPY . .
+
+RUN apt update && apt install -y openssl ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN cargo install --path . --features server && \
+  mv /build/target/release/favicon-rover /favicon-rover && \
+  # cleanup no longer needed build leftovers
+  rm -rf /build /usr/local/rustup /usr/local/cargo
+
+EXPOSE 3000
+ENTRYPOINT ["/favicon-rover", "serve", "--host", "0.0.0.0"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  favicon-rover:
+    container_name: favicon-rover
+    # image: ghcr.io/stevent-team/favicon-rover
+    build: .
+    ports:
+      - "127.0.0.1:3000:3000"
+    command: "--origin '*'"  # put any custom flags for `favicon-rover serve` here
+    restart: unless-stopped


### PR DESCRIPTION
Hey, this PR adds a `Dockerfile`, an example `docker-compose.yml` for quick deployment and a Github Actions workflow to automatically publish Docker images to `ghcr.io` (GitHub Docker Image registry).

This allows users to quickly deploy `favicon-rover` on their server (in my case for usage with `searxng`).

The action should work without settings any additional settings because `secrets.GITHUB_TOKEN` is probably already set as you used it in the `release.yml` action.

I admit that the Dockerfile could be optimized better by using build steps, but when I tried there were some missing runtime dependencies and I couldn't figure out which ones...